### PR TITLE
TtfFont.fillText: Use given size to render text.

### DIFF
--- a/korim/src/commonMain/kotlin/com/soywiz/korim/font/ttf/TtfFont.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/font/ttf/TtfFont.kt
@@ -394,7 +394,7 @@ class TtfFont private constructor(val s: SyncStream) {
 		for (char in text) {
 			val g = getGlyphByChar(char)
 			if (g != null) {
-				g.fill(this, 32.0, TtfFont.Origin.TOP, color)
+				g.fill(this, size, TtfFont.Origin.TOP, color)
 				translate(scale * g.advanceWidth, 0.0)
 			}
 		}


### PR DESCRIPTION
I noticed that TtfFont rendering is always the same size and only spacing between the letters changes with different size arguments.

After taking a look, I am sure the size parameter needs to be respected in TtfFont.fillText().

However, I am unsure about whether "size" or the computed "scale" is appropriate.