### PR TITLE
Fixes BitmapIndexed.toBMP32() for bpp < 8

### DIFF
--- a/korim/src/commonMain/kotlin/com/soywiz/korim/bitmap/Bitmap1.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/bitmap/Bitmap1.kt
@@ -9,5 +9,5 @@ class Bitmap1(
 	data: ByteArray = ByteArray((width * height) divCeil 8),
 	palette: RgbaArray = RgbaArray(2)
 ) : BitmapIndexed(1, width, height, data, palette) {
-	override fun createWithThisFormat(width: Int, height: Int): Bitmap = Bitmap1(width, height)
+	override fun createWithThisFormat(width: Int, height: Int): Bitmap = Bitmap1(width, height, palette = palette)
 }

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/bitmap/Bitmap2.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/bitmap/Bitmap2.kt
@@ -9,5 +9,5 @@ class Bitmap2(
 	data: ByteArray = ByteArray((width * height) divCeil 4),
 	palette: RgbaArray = RgbaArray(4)
 ) : BitmapIndexed(2, width, height, data, palette) {
-	override fun createWithThisFormat(width: Int, height: Int): Bitmap = Bitmap2(width, height)
+	override fun createWithThisFormat(width: Int, height: Int): Bitmap = Bitmap2(width, height, palette = palette)
 }

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/bitmap/Bitmap4.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/bitmap/Bitmap4.kt
@@ -8,5 +8,5 @@ class Bitmap4(
 	data: ByteArray = ByteArray(width * height / 2),
 	palette: RgbaArray = RgbaArray(16)
 ) : BitmapIndexed(4, width, height, data, palette) {
-	override fun createWithThisFormat(width: Int, height: Int): Bitmap = Bitmap4(width, height)
+	override fun createWithThisFormat(width: Int, height: Int): Bitmap = Bitmap4(width, height, palette = palette)
 }

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/bitmap/Bitmap8.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/bitmap/Bitmap8.kt
@@ -8,7 +8,7 @@ class Bitmap8(
 	data: ByteArray = ByteArray(width * height),
 	palette: RgbaArray = RgbaArray(0x100)
 ) : BitmapIndexed(8, width, height, data, palette) {
-	override fun createWithThisFormat(width: Int, height: Int): Bitmap = Bitmap8(width, height)
+	override fun createWithThisFormat(width: Int, height: Int): Bitmap = Bitmap8(width, height, palette = palette)
 
 	override fun setInt(x: Int, y: Int, color: Int) = Unit.apply { datau[index(x, y)] = color }
 	override fun getInt(x: Int, y: Int): Int = datau[index(x, y)]

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/bitmap/BitmapIndexed.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/bitmap/BitmapIndexed.kt
@@ -76,9 +76,10 @@ abstract class BitmapIndexed(
 	}
 
 	override fun toBMP32(): Bitmap32 = Bitmap32(width, height, premultiplied = premultiplied).also { outBmp ->
-		val out = outBmp.data.ints
-		val inp = this@BitmapIndexed.data
-		val pal = this@BitmapIndexed.palette.ints
-		for (n in 0 until min(out.size, inp.size)) out[n] = pal[inp[n].unsigned]
+        val out = outBmp.data.ints
+        val pal = this@BitmapIndexed.palette.ints
+        for (x in 0 until width)
+            for (y in 0 until height)
+                out[y*width+x] = pal[get(x, y)]
 	}
 }


### PR DESCRIPTION
BitmapIndexed.toBMP32() throws an java.lang.ArrayIndexOutOfBoundsException for bpp smaller than 8.

Minimal repro:
```kotlin
val bpp4 = Bitmap4(2, 1)
bpp4[0, 0] = 1
bpp4[1, 0] = 1
bpp4.palette = RgbaArray(16)
bpp4.toBMP32()
```